### PR TITLE
chore(ci): update of CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   CLAAssistant:
-    if: github.event.pull_request.draft == false
     permissions:
       actions: write
       contents: write
@@ -21,7 +20,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 #v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
@@ -33,4 +32,3 @@ jobs:
           allowlist: NetcrackerCLPLCI,web-flow,bot*
           remote-repository-name: cla-storage
           remote-organization-name: Netcracker
-

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened]
 
 permissions:
   contents: read
@@ -20,13 +20,13 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 #v2.6.1
+        uses: Netcracker/qubership-workflow-hub/actions/cla-assistant@e64a1ee2fc2f68ab44a4ef416c27d83ce36ba8e1 # v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/Netcracker/qubership-github-workflows/blob/main/CLA/cla.md'
+          path-to-document: 'https://github.com/Netcracker/qubership-workflow-hub/blob/release/v2.2.0/CLA/cla.md'
           # branch should not be protected
           branch: 'main'
           allowlist: NetcrackerCLPLCI,web-flow,bot*


### PR DESCRIPTION
Switching to our own copy of the CLAAssistant action, as the original action has been archived. Plus, our version has been rewritten for Node.24.