### PR TITLE
Make repository AI-ready with APM agent packages

### DIFF
--- a/.agents/skills/apihub-agents-backend-developer/SKILL.md
+++ b/.agents/skills/apihub-agents-backend-developer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: apihub-agents-backend-developer
+description: "Implements and modifies the APIHUB Agents Backend Go service (qubership-apihub-agents-backend): agent CRUD, discovery orchestration, snapshots, proxy, namespace security, env-only config, and OpenAPI specs. Use when adding or changing agents-backend features, REST endpoints, SQL migrations, repository queries, or Go code in qubership-apihub-agents-backend."
+---
+
+# APIHUB Agents Backend Developer
+
+**Follow `apihub-go-developer` first** — this skill adds agents-backend-specific rules for `qubership-apihub-agents-backend` only.
+
+Follow `AGENTS.md` and project rules. For examples and doc routing, see [reference.md](reference.md).
+
+## Agents-backend-specific workflow
+
+1. **Errors** — new API error codes/messages as constants in `exception/errors.go`.
+2. **Wiring** — new repos/services/controllers at the **end** of their section in `service.go`; `log.Fatalf` / `panic` for fatal startup wiring errors (match existing patterns).
+3. **Config** — all runtime settings via environment variables read in `service/system_info.go`; do not introduce YAML config files.
+4. **Migrations** — files in `qubership-apihub-agents-backend/resources/migrations/`; use next unused numeric prefix.
+5. **OpenAPI** — update `docs/api/*.yaml` when REST contract changes (see deployed `agents-backend-conventions` rules).
+6. **Related repos** — if the change touches deploy config, env vars, or REST contracts, remind the developer about Helm charts and/or the agent repo per `AGENTS.md`.
+
+## Domain areas (read before changing behaviour)
+
+| Area | Key files |
+|------|-----------|
+| Agent CRUD / heartbeats | `service/agent.go`, `controller/agent.go`, `repository/agent.go` |
+| Discovery orchestration | `service/discovery.go`, `controller/discovery.go`, `client/agent.go` |
+| Snapshots | `service/snapshot.go`, `controller/snapshot.go`, `service/cleanup.go` |
+| Agent proxy | `controller/proxy.go`, routes in `service.go` |
+| Namespace security | `service/namespace_security.go`, `controller/namespace_security.go` |
+| APIHUB integration | `client/apihub.go`, `service/permission.go` |
+
+## Startup and migration pattern
+
+`service.go` starts a temporary init HTTP server, runs DB migrations in a goroutine, shuts down the init server, then continues full wiring. Do not reorder this sequence without understanding health/readiness (`/live`, `/ready`) and migration failure handling.
+
+## Completion checklist (agents-backend additions)
+
+In addition to the `apihub-go-developer` checklist:
+
+- [ ] Go conventions and `service.go` / `exception/errors.go` rules followed.
+- [ ] REST changes reflected in `docs/api/*.yaml`.
+- [ ] New env vars documented in `service/system_info.go` and `agents-backend-conventions` rules.
+- [ ] Migrations use unique numeric prefix.
+- [ ] **Related repositories** — if applicable, reminded developer about Helm and/or agent repo updates (see `AGENTS.md`).
+
+### Related repositories (reminder block)
+
+When the feature matches criteria in `AGENTS.md`, end your message with:
+
+```markdown
+### Related repositories (follow-up outside this repo)
+- **Helm**: <what to check + repo URL from AGENTS.md>
+- **Agent**: <what to add/update + repo URL>
+```
+
+Omit sections that do not apply.
+
+Suggest invoking `apihub-go-self-review` in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.agents/skills/apihub-agents-backend-developer/reference.md
+++ b/.agents/skills/apihub-agents-backend-developer/reference.md
@@ -1,0 +1,61 @@
+# APIHUB Agents Backend Developer — Reference
+
+Read this file when you need agents-backend-specific examples or doc-routing detail. Keep `SKILL.md` as the workflow checklist. Generic patterns are in `apihub-go-developer/reference.md`.
+
+## Doc routing (where to update documentation)
+
+| Change type | Update |
+|-------------|--------|
+| New or changed REST contract | `docs/api/Agents-Backend-API.yaml` (+ `Admin-API.yaml`, `Agents-Backend-API_internal.yaml` if applicable) |
+| Operational / architecture notes | `docs/recources/` (existing diagrams) |
+| AI assistant behaviour | `AGENTS.md`, `agent-packages/` |
+
+## Environment variables
+
+All configuration is env-only via `service/system_info.go`. Key groups:
+
+| Group | Variables |
+|-------|-----------|
+| PostgreSQL | `AGENTS_BACKEND_POSTGRESQL_HOST`, `AGENTS_BACKEND_POSTGRESQL_PORT`, `AGENTS_BACKEND_POSTGRESQL_DB_NAME`, `AGENTS_BACKEND_POSTGRESQL_USERNAME`, `AGENTS_BACKEND_POSTGRESQL_PASSWORD` |
+| APIHUB | `APIHUB_URL`, `APIHUB_ACCESS_TOKEN` |
+| Paths | `BASE_PATH`, `API_SPEC_DIR` |
+| Server | `LISTEN_ADDRESS`, `ORIGIN_ALLOWED`, `LOG_LEVEL` |
+| Snapshots cleanup | `SNAPSHOTS_CLEANUP_SCHEDULE`, `SNAPSHOTS_TTL_DAYS` |
+| Proxy (deprecated path) | `INSECURE_PROXY` |
+
+## Error codes (`exception/errors.go`)
+
+**Good:**
+
+```go
+const AgentNotFound = "4"
+const AgentNotFoundMsg = "Agent '$agentId' not found"
+```
+
+Use existing patterns for parameter placeholders (`$agentId`, `$param`, etc.). Do not inline error code strings in controllers or services.
+
+## service.go wiring
+
+- Add `repository.New...` with other repository constructors (end of repository block).
+- Add `service.New...` with other services (end of service block).
+- Add `controller.New...` with other controllers (end of controller block).
+- Use `log.Fatalf` or `panic` when service construction failure must stop startup (see existing patterns).
+
+## Migration files
+
+Naming: `{N}_{description}.up.sql` and `{N}_{description}.down.sql` where `N` is the next free integer.
+
+Directory: `qubership-apihub-agents-backend/resources/migrations/`
+
+## OpenAPI files
+
+| File | Purpose |
+|------|---------|
+| `docs/api/Agents-Backend-API.yaml` | Public REST API |
+| `docs/api/Admin-API.yaml` | Admin/debug endpoints |
+| `docs/api/Agents-Backend-API_internal.yaml` | Internal endpoints |
+
+## Further reading
+
+- `AGENTS.md` — agent contract (loaded every session)
+- `LLM/qubership-apihub-agents-backend.md` — architecture overview (when available in workspace)

--- a/.agents/skills/apihub-go-developer/SKILL.md
+++ b/.agents/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.agents/skills/apihub-go-developer/reference.md
+++ b/.agents/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.agents/skills/apihub-go-self-review/SKILL.md
+++ b/.agents/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.agents/skills/english-developer-style/SKILL.md
+++ b/.agents/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.agents/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.agents/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.claude/rules/agents-backend-api-spec-exposer.md
+++ b/.claude/rules/agents-backend-api-spec-exposer.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "qubership-apihub-agents-backend/service.go"
+  - "docs/api/**"
+---
+
+# Agents Backend API Spec Exposer
+
+- OpenAPI specs under `docs/api/` are exposed at runtime via `github.com/Netcracker/qubership-apihub-commons-go/api-spec-exposer`.
+- **Scan directory:** `API_SPEC_DIR` env var (default: `{BASE_PATH}/api`); place or symlink specs so discovery finds them.
+- **Registration:** in `service.go`, `exposer.New(discoveryConfig).Discover()` registers GET handlers for each discovered spec; discovery errors are fatal (`panic`).
+- When adding or renaming spec files, ensure they are discoverable under `API_SPEC_DIR` and update the source YAML in `docs/api/`.

--- a/.claude/rules/agents-backend-env-vars.md
+++ b/.claude/rules/agents-backend-env-vars.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "qubership-apihub-agents-backend/service/system_info.go"
+  - "qubership-apihub-agents-backend/**/*.go"
+---
+
+# Agents Backend Environment Variables
+
+- **Single source of truth:** `service/system_info.go` — read env vars in `Init()` and expose via `SystemInfoService` getters.
+- **No YAML config** — do not add viper/config files; all runtime settings are environment variables.
+- **PostgreSQL:** use `AGENTS_BACKEND_POSTGRESQL_*` prefix (`HOST`, `PORT`, `DB_NAME`, `USERNAME`, `PASSWORD`).
+- **Defaults:** define defaults in `system_info.go` setters (e.g. `localhost`, `5432`, `apihub_agents_backend`) — do not duplicate as scattered literals in services.
+- **New env var:** add constant, setter, getter in `system_info.go`; wire usage in services; update Helm values in `qubership-apihub` when deploy-visible.

--- a/.claude/rules/agents-backend-migrations.md
+++ b/.claude/rules/agents-backend-migrations.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/resources/migrations/**"
+---
+
+# Agents Backend Database Migrations
+
+- Migrations live in `qubership-apihub-agents-backend/resources/migrations/`.
+- Use the next unused numeric prefix (current highest is visible in that directory).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- Migrations run at startup via `DBMigrationService` while the init HTTP server is listening; failure stops the process.

--- a/.claude/rules/agents-backend-openapi.md
+++ b/.claude/rules/agents-backend-openapi.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "docs/api/**"
+  - "qubership-apihub-agents-backend/controller/**"
+---
+
+# Agents Backend OpenAPI Files
+
+Any REST endpoint or contract change **must** update the relevant OpenAPI files under `docs/api/`:
+
+- Public API: `docs/api/Agents-Backend-API.yaml`
+- Admin API: `docs/api/Admin-API.yaml`
+- Internal API: `docs/api/Agents-Backend-API_internal.yaml` (when internal endpoints change)
+
+Do not introduce breaking public API changes without versioning and deprecation.

--- a/.claude/rules/api-first-openapi.md
+++ b/.claude/rules/api-first-openapi.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "docs/api/**"
+  - "**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.claude/rules/apihub-agents-backend-developer.md
+++ b/.claude/rules/apihub-agents-backend-developer.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "qubership-apihub-agents-backend/**/*.go"
+---
+
+When implementing or modifying the APIHUB Agents Backend Go service (controllers, services,
+repositories, migrations, service.go wiring, exception errors, or OpenAPI specs) in
+`qubership-apihub-agents-backend`, apply the `apihub-agents-backend-developer` skill.

--- a/.claude/rules/apihub-go-developer.md
+++ b/.claude/rules/apihub-go-developer.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.claude/rules/apihub-go-self-review.md
+++ b/.claude/rules/apihub-go-self-review.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.claude/rules/ci-super-linter.md
+++ b/.claude/rules/ci-super-linter.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "**/*.{md,go,yaml,yml}"
+---
+
+# CI linters (super-linter / link checker)
+
+GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+
+## EditorConfig (Go)
+
+- `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
+
+## Markdown (markdownlint)
+
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
+- Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
+
+## Natural language (textlint)
+
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
+- Do not add `REST` as a forced term — it causes false positives on the word "rest".
+
+## Markdown links (lychee)
+
+- Links must resolve from the **file's directory** (count `../` carefully).
+- Prefer stable repo-relative links; external URLs must be reachable.
+
+## OpenAPI / YAML
+
+- No trailing whitespace on changed lines in `docs/api/*.yaml`.
+- Match surrounding indentation in large specs; do not reformat unrelated blocks.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+
+## SQL migrations (sqlfluff)
+
+- Unique numeric prefix; paired `.up.sql` / `.down.sql` when applicable.
+- Project config in `.sqlfluff` excludes some rules; avoid unnecessary style churn.
+
+## Before finishing
+
+- After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
+- Run migration number script when migrations change (see migration rules).

--- a/.claude/rules/clarify-before-coding.md
+++ b/.claude/rules/clarify-before-coding.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "**"
+---
+
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.claude/rules/english-developer-style.md
+++ b/.claude/rules/english-developer-style.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.claude/rules/github-ticket-implementation-planner.md
+++ b/.claude/rules/github-ticket-implementation-planner.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.claude/rules/go-comments.md
+++ b/.claude/rules/go-comments.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.claude/rules/go-constants-and-http.md
+++ b/.claude/rules/go-constants-and-http.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.claude/rules/go-error-handling.md
+++ b/.claude/rules/go-error-handling.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.claude/rules/go-migrations.md
+++ b/.claude/rules/go-migrations.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.claude/rules/sql-performance.md
+++ b/.claude/rules/sql-performance.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.claude/skills/apihub-agents-backend-developer/SKILL.md
+++ b/.claude/skills/apihub-agents-backend-developer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: apihub-agents-backend-developer
+description: "Implements and modifies the APIHUB Agents Backend Go service (qubership-apihub-agents-backend): agent CRUD, discovery orchestration, snapshots, proxy, namespace security, env-only config, and OpenAPI specs. Use when adding or changing agents-backend features, REST endpoints, SQL migrations, repository queries, or Go code in qubership-apihub-agents-backend."
+---
+
+# APIHUB Agents Backend Developer
+
+**Follow `apihub-go-developer` first** — this skill adds agents-backend-specific rules for `qubership-apihub-agents-backend` only.
+
+Follow `AGENTS.md` and project rules. For examples and doc routing, see [reference.md](reference.md).
+
+## Agents-backend-specific workflow
+
+1. **Errors** — new API error codes/messages as constants in `exception/errors.go`.
+2. **Wiring** — new repos/services/controllers at the **end** of their section in `service.go`; `log.Fatalf` / `panic` for fatal startup wiring errors (match existing patterns).
+3. **Config** — all runtime settings via environment variables read in `service/system_info.go`; do not introduce YAML config files.
+4. **Migrations** — files in `qubership-apihub-agents-backend/resources/migrations/`; use next unused numeric prefix.
+5. **OpenAPI** — update `docs/api/*.yaml` when REST contract changes (see deployed `agents-backend-conventions` rules).
+6. **Related repos** — if the change touches deploy config, env vars, or REST contracts, remind the developer about Helm charts and/or the agent repo per `AGENTS.md`.
+
+## Domain areas (read before changing behaviour)
+
+| Area | Key files |
+|------|-----------|
+| Agent CRUD / heartbeats | `service/agent.go`, `controller/agent.go`, `repository/agent.go` |
+| Discovery orchestration | `service/discovery.go`, `controller/discovery.go`, `client/agent.go` |
+| Snapshots | `service/snapshot.go`, `controller/snapshot.go`, `service/cleanup.go` |
+| Agent proxy | `controller/proxy.go`, routes in `service.go` |
+| Namespace security | `service/namespace_security.go`, `controller/namespace_security.go` |
+| APIHUB integration | `client/apihub.go`, `service/permission.go` |
+
+## Startup and migration pattern
+
+`service.go` starts a temporary init HTTP server, runs DB migrations in a goroutine, shuts down the init server, then continues full wiring. Do not reorder this sequence without understanding health/readiness (`/live`, `/ready`) and migration failure handling.
+
+## Completion checklist (agents-backend additions)
+
+In addition to the `apihub-go-developer` checklist:
+
+- [ ] Go conventions and `service.go` / `exception/errors.go` rules followed.
+- [ ] REST changes reflected in `docs/api/*.yaml`.
+- [ ] New env vars documented in `service/system_info.go` and `agents-backend-conventions` rules.
+- [ ] Migrations use unique numeric prefix.
+- [ ] **Related repositories** — if applicable, reminded developer about Helm and/or agent repo updates (see `AGENTS.md`).
+
+### Related repositories (reminder block)
+
+When the feature matches criteria in `AGENTS.md`, end your message with:
+
+```markdown
+### Related repositories (follow-up outside this repo)
+- **Helm**: <what to check + repo URL from AGENTS.md>
+- **Agent**: <what to add/update + repo URL>
+```
+
+Omit sections that do not apply.
+
+Suggest invoking `apihub-go-self-review` in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.claude/skills/apihub-agents-backend-developer/reference.md
+++ b/.claude/skills/apihub-agents-backend-developer/reference.md
@@ -1,0 +1,61 @@
+# APIHUB Agents Backend Developer — Reference
+
+Read this file when you need agents-backend-specific examples or doc-routing detail. Keep `SKILL.md` as the workflow checklist. Generic patterns are in `apihub-go-developer/reference.md`.
+
+## Doc routing (where to update documentation)
+
+| Change type | Update |
+|-------------|--------|
+| New or changed REST contract | `docs/api/Agents-Backend-API.yaml` (+ `Admin-API.yaml`, `Agents-Backend-API_internal.yaml` if applicable) |
+| Operational / architecture notes | `docs/recources/` (existing diagrams) |
+| AI assistant behaviour | `AGENTS.md`, `agent-packages/` |
+
+## Environment variables
+
+All configuration is env-only via `service/system_info.go`. Key groups:
+
+| Group | Variables |
+|-------|-----------|
+| PostgreSQL | `AGENTS_BACKEND_POSTGRESQL_HOST`, `AGENTS_BACKEND_POSTGRESQL_PORT`, `AGENTS_BACKEND_POSTGRESQL_DB_NAME`, `AGENTS_BACKEND_POSTGRESQL_USERNAME`, `AGENTS_BACKEND_POSTGRESQL_PASSWORD` |
+| APIHUB | `APIHUB_URL`, `APIHUB_ACCESS_TOKEN` |
+| Paths | `BASE_PATH`, `API_SPEC_DIR` |
+| Server | `LISTEN_ADDRESS`, `ORIGIN_ALLOWED`, `LOG_LEVEL` |
+| Snapshots cleanup | `SNAPSHOTS_CLEANUP_SCHEDULE`, `SNAPSHOTS_TTL_DAYS` |
+| Proxy (deprecated path) | `INSECURE_PROXY` |
+
+## Error codes (`exception/errors.go`)
+
+**Good:**
+
+```go
+const AgentNotFound = "4"
+const AgentNotFoundMsg = "Agent '$agentId' not found"
+```
+
+Use existing patterns for parameter placeholders (`$agentId`, `$param`, etc.). Do not inline error code strings in controllers or services.
+
+## service.go wiring
+
+- Add `repository.New...` with other repository constructors (end of repository block).
+- Add `service.New...` with other services (end of service block).
+- Add `controller.New...` with other controllers (end of controller block).
+- Use `log.Fatalf` or `panic` when service construction failure must stop startup (see existing patterns).
+
+## Migration files
+
+Naming: `{N}_{description}.up.sql` and `{N}_{description}.down.sql` where `N` is the next free integer.
+
+Directory: `qubership-apihub-agents-backend/resources/migrations/`
+
+## OpenAPI files
+
+| File | Purpose |
+|------|---------|
+| `docs/api/Agents-Backend-API.yaml` | Public REST API |
+| `docs/api/Admin-API.yaml` | Admin/debug endpoints |
+| `docs/api/Agents-Backend-API_internal.yaml` | Internal endpoints |
+
+## Further reading
+
+- `AGENTS.md` — agent contract (loaded every session)
+- `LLM/qubership-apihub-agents-backend.md` — architecture overview (when available in workspace)

--- a/.claude/skills/apihub-go-developer/SKILL.md
+++ b/.claude/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.claude/skills/apihub-go-developer/reference.md
+++ b/.claude/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.claude/skills/apihub-go-self-review/SKILL.md
+++ b/.claude/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.claude/skills/english-developer-style/SKILL.md
+++ b/.claude/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.claude/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.claude/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.cursor/rules/agents-backend-api-spec-exposer.mdc
+++ b/.cursor/rules/agents-backend-api-spec-exposer.mdc
@@ -1,0 +1,13 @@
+---
+description: Agents-backend API spec discovery via commons-go api-spec-exposer
+globs:
+  - "qubership-apihub-agents-backend/service.go"
+  - "docs/api/**"
+---
+
+# Agents Backend API Spec Exposer
+
+- OpenAPI specs under `docs/api/` are exposed at runtime via `github.com/Netcracker/qubership-apihub-commons-go/api-spec-exposer`.
+- **Scan directory:** `API_SPEC_DIR` env var (default: `{BASE_PATH}/api`); place or symlink specs so discovery finds them.
+- **Registration:** in `service.go`, `exposer.New(discoveryConfig).Discover()` registers GET handlers for each discovered spec; discovery errors are fatal (`panic`).
+- When adding or renaming spec files, ensure they are discoverable under `API_SPEC_DIR` and update the source YAML in `docs/api/`.

--- a/.cursor/rules/agents-backend-env-vars.mdc
+++ b/.cursor/rules/agents-backend-env-vars.mdc
@@ -1,0 +1,14 @@
+---
+description: Agents-backend environment variable conventions
+globs:
+  - "qubership-apihub-agents-backend/service/system_info.go"
+  - "qubership-apihub-agents-backend/**/*.go"
+---
+
+# Agents Backend Environment Variables
+
+- **Single source of truth:** `service/system_info.go` — read env vars in `Init()` and expose via `SystemInfoService` getters.
+- **No YAML config** — do not add viper/config files; all runtime settings are environment variables.
+- **PostgreSQL:** use `AGENTS_BACKEND_POSTGRESQL_*` prefix (`HOST`, `PORT`, `DB_NAME`, `USERNAME`, `PASSWORD`).
+- **Defaults:** define defaults in `system_info.go` setters (e.g. `localhost`, `5432`, `apihub_agents_backend`) — do not duplicate as scattered literals in services.
+- **New env var:** add constant, setter, getter in `system_info.go`; wire usage in services; update Helm values in `qubership-apihub` when deploy-visible.

--- a/.cursor/rules/agents-backend-migrations.mdc
+++ b/.cursor/rules/agents-backend-migrations.mdc
@@ -1,0 +1,12 @@
+---
+description: Agents-backend SQL migration path conventions
+globs: "**/resources/migrations/**"
+---
+
+# Agents Backend Database Migrations
+
+- Migrations live in `qubership-apihub-agents-backend/resources/migrations/`.
+- Use the next unused numeric prefix (current highest is visible in that directory).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- Migrations run at startup via `DBMigrationService` while the init HTTP server is listening; failure stops the process.

--- a/.cursor/rules/agents-backend-openapi.mdc
+++ b/.cursor/rules/agents-backend-openapi.mdc
@@ -1,0 +1,16 @@
+---
+description: Agents-backend OpenAPI file list and sync requirements
+globs:
+  - "docs/api/**"
+  - "qubership-apihub-agents-backend/controller/**"
+---
+
+# Agents Backend OpenAPI Files
+
+Any REST endpoint or contract change **must** update the relevant OpenAPI files under `docs/api/`:
+
+- Public API: `docs/api/Agents-Backend-API.yaml`
+- Admin API: `docs/api/Admin-API.yaml`
+- Internal API: `docs/api/Agents-Backend-API_internal.yaml` (when internal endpoints change)
+
+Do not introduce breaking public API changes without versioning and deprecation.

--- a/.cursor/rules/api-first-openapi.mdc
+++ b/.cursor/rules/api-first-openapi.mdc
@@ -1,0 +1,12 @@
+---
+description: API-first OpenAPI sync principle for REST changes
+globs:
+  - "docs/api/**"
+  - "**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.cursor/rules/apihub-agents-backend-developer.mdc
+++ b/.cursor/rules/apihub-agents-backend-developer.mdc
@@ -1,0 +1,8 @@
+---
+description: Agents-backend development workflow for qubership-apihub-agents-backend.
+globs: "qubership-apihub-agents-backend/**/*.go"
+---
+
+When implementing or modifying the APIHUB Agents Backend Go service (controllers, services,
+repositories, migrations, service.go wiring, exception errors, or OpenAPI specs) in
+`qubership-apihub-agents-backend`, apply the `apihub-agents-backend-developer` skill.

--- a/.cursor/rules/apihub-go-developer.mdc
+++ b/.cursor/rules/apihub-go-developer.mdc
@@ -1,0 +1,8 @@
+---
+description: Go backend development workflow for APIHub services.
+globs: "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.cursor/rules/apihub-go-self-review.mdc
+++ b/.cursor/rules/apihub-go-self-review.mdc
@@ -1,0 +1,8 @@
+---
+description: Self-review Go backend changes against APIHub project standards.
+globs: "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.cursor/rules/ci-super-linter.mdc
+++ b/.cursor/rules/ci-super-linter.mdc
@@ -1,30 +1,42 @@
 ---
-description: CI super-linter and link-check rules for docs, Go, and YAML
-globs: "**/*.{md,go,yaml,yml}"
+description: CI super-linter and MD link checker rules for changed files in APIHub repositories
+globs: "**"
 ---
 
 # CI linters (super-linter / link checker)
 
-GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+GitHub Actions runs **super-linter** on changed files (many languages and formats) and **lychee** on
+repository Markdown. Follow these rules when you add or edit files so PR checks pass without a
+follow-up lint commit.
 
-Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`,
+`.github/linters/.markdownlint.json`, `.github/linters/.textlintrc`, `.github/super-linter.env`,
+`.github/workflows/super-linter.yaml`, `.github/workflows/link-checker.yaml`.
 
-## EditorConfig (Go)
+APM-deployed harness trees (`.cursor/`, `.claude/`, `.agents/`, `agent-packages/`, compiled
+`AGENTS.md`) are excluded from CI linters — edit package sources under `agent-packages/` when
+changing skills or rules.
+
+## EditorConfig
 
 - `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
-- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look
+  indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
 - Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
 
 ## Markdown (markdownlint)
 
-- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
-- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default
+  for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks
+  instead of one very long line.
 - Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
 - Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
 
 ## Natural language (textlint)
 
-- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`,
+  `APIs`, `end-to-end`).
 - Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
 - Do not add `REST` as a forced term — it causes false positives on the word "rest".
 
@@ -37,7 +49,8 @@ Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`
 
 - No trailing whitespace on changed lines in `docs/api/*.yaml`.
 - Match surrounding indentation in large specs; do not reformat unrelated blocks.
-- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description`
+  next to `$ref`.
 
 ## SQL migrations (sqlfluff)
 
@@ -47,4 +60,4 @@ Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`
 ## Before finishing
 
 - After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
-- Run migration number script when migrations change (see migration rules).
+- When Go SQL migrations change, run the migration number check script (see migration rules).

--- a/.cursor/rules/ci-super-linter.mdc
+++ b/.cursor/rules/ci-super-linter.mdc
@@ -1,0 +1,50 @@
+---
+description: CI super-linter and link-check rules for docs, Go, and YAML
+globs: "**/*.{md,go,yaml,yml}"
+---
+
+# CI linters (super-linter / link checker)
+
+GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+
+## EditorConfig (Go)
+
+- `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
+
+## Markdown (markdownlint)
+
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
+- Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
+
+## Natural language (textlint)
+
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
+- Do not add `REST` as a forced term — it causes false positives on the word "rest".
+
+## Markdown links (lychee)
+
+- Links must resolve from the **file's directory** (count `../` carefully).
+- Prefer stable repo-relative links; external URLs must be reachable.
+
+## OpenAPI / YAML
+
+- No trailing whitespace on changed lines in `docs/api/*.yaml`.
+- Match surrounding indentation in large specs; do not reformat unrelated blocks.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+
+## SQL migrations (sqlfluff)
+
+- Unique numeric prefix; paired `.up.sql` / `.down.sql` when applicable.
+- Project config in `.sqlfluff` excludes some rules; avoid unnecessary style churn.
+
+## Before finishing
+
+- After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
+- Run migration number script when migrations change (see migration rules).

--- a/.cursor/rules/clarify-before-coding.mdc
+++ b/.cursor/rules/clarify-before-coding.mdc
@@ -1,0 +1,10 @@
+---
+description: Ask clarifying questions before generating code when requirements are unclear
+globs: "**"
+---
+
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.cursor/rules/english-developer-style.mdc
+++ b/.cursor/rules/english-developer-style.mdc
@@ -1,0 +1,52 @@
+---
+description: British-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
+globs: "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.cursor/rules/github-ticket-implementation-planner.mdc
+++ b/.cursor/rules/github-ticket-implementation-planner.mdc
@@ -1,0 +1,7 @@
+---
+description: Plan implementation from a GitHub issue with clarifying questions and approved plan posting.
+globs: "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.cursor/rules/go-comments.mdc
+++ b/.cursor/rules/go-comments.mdc
@@ -1,0 +1,21 @@
+---
+description: Go comment policy and entity-to-view converter naming
+globs: "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.cursor/rules/go-constants-and-http.mdc
+++ b/.cursor/rules/go-constants-and-http.mdc
@@ -1,0 +1,18 @@
+---
+description: Go constants, literals, and HTTP status code conventions
+globs: "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.cursor/rules/go-error-handling.mdc
+++ b/.cursor/rules/go-error-handling.mdc
@@ -1,0 +1,12 @@
+---
+description: Go error handling — fail fast and fix root cause
+globs: "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.cursor/rules/go-migrations.mdc
+++ b/.cursor/rules/go-migrations.mdc
@@ -1,0 +1,11 @@
+---
+description: SQL migration numbering and file conventions
+globs: "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.cursor/rules/sql-performance.mdc
+++ b/.cursor/rules/sql-performance.mdc
@@ -1,0 +1,14 @@
+---
+description: SQL performance review for repository changes
+globs: "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.cursor/skills/apihub-agents-backend-developer/SKILL.md
+++ b/.cursor/skills/apihub-agents-backend-developer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: apihub-agents-backend-developer
+description: "Implements and modifies the APIHUB Agents Backend Go service (qubership-apihub-agents-backend): agent CRUD, discovery orchestration, snapshots, proxy, namespace security, env-only config, and OpenAPI specs. Use when adding or changing agents-backend features, REST endpoints, SQL migrations, repository queries, or Go code in qubership-apihub-agents-backend."
+---
+
+# APIHUB Agents Backend Developer
+
+**Follow `apihub-go-developer` first** — this skill adds agents-backend-specific rules for `qubership-apihub-agents-backend` only.
+
+Follow `AGENTS.md` and project rules. For examples and doc routing, see [reference.md](reference.md).
+
+## Agents-backend-specific workflow
+
+1. **Errors** — new API error codes/messages as constants in `exception/errors.go`.
+2. **Wiring** — new repos/services/controllers at the **end** of their section in `service.go`; `log.Fatalf` / `panic` for fatal startup wiring errors (match existing patterns).
+3. **Config** — all runtime settings via environment variables read in `service/system_info.go`; do not introduce YAML config files.
+4. **Migrations** — files in `qubership-apihub-agents-backend/resources/migrations/`; use next unused numeric prefix.
+5. **OpenAPI** — update `docs/api/*.yaml` when REST contract changes (see deployed `agents-backend-conventions` rules).
+6. **Related repos** — if the change touches deploy config, env vars, or REST contracts, remind the developer about Helm charts and/or the agent repo per `AGENTS.md`.
+
+## Domain areas (read before changing behaviour)
+
+| Area | Key files |
+|------|-----------|
+| Agent CRUD / heartbeats | `service/agent.go`, `controller/agent.go`, `repository/agent.go` |
+| Discovery orchestration | `service/discovery.go`, `controller/discovery.go`, `client/agent.go` |
+| Snapshots | `service/snapshot.go`, `controller/snapshot.go`, `service/cleanup.go` |
+| Agent proxy | `controller/proxy.go`, routes in `service.go` |
+| Namespace security | `service/namespace_security.go`, `controller/namespace_security.go` |
+| APIHUB integration | `client/apihub.go`, `service/permission.go` |
+
+## Startup and migration pattern
+
+`service.go` starts a temporary init HTTP server, runs DB migrations in a goroutine, shuts down the init server, then continues full wiring. Do not reorder this sequence without understanding health/readiness (`/live`, `/ready`) and migration failure handling.
+
+## Completion checklist (agents-backend additions)
+
+In addition to the `apihub-go-developer` checklist:
+
+- [ ] Go conventions and `service.go` / `exception/errors.go` rules followed.
+- [ ] REST changes reflected in `docs/api/*.yaml`.
+- [ ] New env vars documented in `service/system_info.go` and `agents-backend-conventions` rules.
+- [ ] Migrations use unique numeric prefix.
+- [ ] **Related repositories** — if applicable, reminded developer about Helm and/or agent repo updates (see `AGENTS.md`).
+
+### Related repositories (reminder block)
+
+When the feature matches criteria in `AGENTS.md`, end your message with:
+
+```markdown
+### Related repositories (follow-up outside this repo)
+- **Helm**: <what to check + repo URL from AGENTS.md>
+- **Agent**: <what to add/update + repo URL>
+```
+
+Omit sections that do not apply.
+
+Suggest invoking `apihub-go-self-review` in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.cursor/skills/apihub-agents-backend-developer/reference.md
+++ b/.cursor/skills/apihub-agents-backend-developer/reference.md
@@ -1,0 +1,61 @@
+# APIHUB Agents Backend Developer — Reference
+
+Read this file when you need agents-backend-specific examples or doc-routing detail. Keep `SKILL.md` as the workflow checklist. Generic patterns are in `apihub-go-developer/reference.md`.
+
+## Doc routing (where to update documentation)
+
+| Change type | Update |
+|-------------|--------|
+| New or changed REST contract | `docs/api/Agents-Backend-API.yaml` (+ `Admin-API.yaml`, `Agents-Backend-API_internal.yaml` if applicable) |
+| Operational / architecture notes | `docs/recources/` (existing diagrams) |
+| AI assistant behaviour | `AGENTS.md`, `agent-packages/` |
+
+## Environment variables
+
+All configuration is env-only via `service/system_info.go`. Key groups:
+
+| Group | Variables |
+|-------|-----------|
+| PostgreSQL | `AGENTS_BACKEND_POSTGRESQL_HOST`, `AGENTS_BACKEND_POSTGRESQL_PORT`, `AGENTS_BACKEND_POSTGRESQL_DB_NAME`, `AGENTS_BACKEND_POSTGRESQL_USERNAME`, `AGENTS_BACKEND_POSTGRESQL_PASSWORD` |
+| APIHUB | `APIHUB_URL`, `APIHUB_ACCESS_TOKEN` |
+| Paths | `BASE_PATH`, `API_SPEC_DIR` |
+| Server | `LISTEN_ADDRESS`, `ORIGIN_ALLOWED`, `LOG_LEVEL` |
+| Snapshots cleanup | `SNAPSHOTS_CLEANUP_SCHEDULE`, `SNAPSHOTS_TTL_DAYS` |
+| Proxy (deprecated path) | `INSECURE_PROXY` |
+
+## Error codes (`exception/errors.go`)
+
+**Good:**
+
+```go
+const AgentNotFound = "4"
+const AgentNotFoundMsg = "Agent '$agentId' not found"
+```
+
+Use existing patterns for parameter placeholders (`$agentId`, `$param`, etc.). Do not inline error code strings in controllers or services.
+
+## service.go wiring
+
+- Add `repository.New...` with other repository constructors (end of repository block).
+- Add `service.New...` with other services (end of service block).
+- Add `controller.New...` with other controllers (end of controller block).
+- Use `log.Fatalf` or `panic` when service construction failure must stop startup (see existing patterns).
+
+## Migration files
+
+Naming: `{N}_{description}.up.sql` and `{N}_{description}.down.sql` where `N` is the next free integer.
+
+Directory: `qubership-apihub-agents-backend/resources/migrations/`
+
+## OpenAPI files
+
+| File | Purpose |
+|------|---------|
+| `docs/api/Agents-Backend-API.yaml` | Public REST API |
+| `docs/api/Admin-API.yaml` | Admin/debug endpoints |
+| `docs/api/Agents-Backend-API_internal.yaml` | Internal endpoints |
+
+## Further reading
+
+- `AGENTS.md` — agent contract (loaded every session)
+- `LLM/qubership-apihub-agents-backend.md` — architecture overview (when available in workspace)

--- a/.cursor/skills/apihub-go-developer/SKILL.md
+++ b/.cursor/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.cursor/skills/apihub-go-developer/reference.md
+++ b/.cursor/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.cursor/skills/apihub-go-self-review/SKILL.md
+++ b/.cursor/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.cursor/skills/english-developer-style/SKILL.md
+++ b/.cursor/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.cursor/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.cursor/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.github/instructions/agents-backend-api-spec-exposer.instructions.md
+++ b/.github/instructions/agents-backend-api-spec-exposer.instructions.md
@@ -1,0 +1,11 @@
+---
+description: Agents-backend API spec discovery via commons-go api-spec-exposer
+applyTo: qubership-apihub-agents-backend/service.go,docs/api/**
+---
+
+# Agents Backend API Spec Exposer
+
+- OpenAPI specs under `docs/api/` are exposed at runtime via `github.com/Netcracker/qubership-apihub-commons-go/api-spec-exposer`.
+- **Scan directory:** `API_SPEC_DIR` env var (default: `{BASE_PATH}/api`); place or symlink specs so discovery finds them.
+- **Registration:** in `service.go`, `exposer.New(discoveryConfig).Discover()` registers GET handlers for each discovered spec; discovery errors are fatal (`panic`).
+- When adding or renaming spec files, ensure they are discoverable under `API_SPEC_DIR` and update the source YAML in `docs/api/`.

--- a/.github/instructions/agents-backend-env-vars.instructions.md
+++ b/.github/instructions/agents-backend-env-vars.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Agents-backend environment variable conventions
+applyTo: qubership-apihub-agents-backend/service/system_info.go,qubership-apihub-agents-backend/**/*.go
+---
+
+# Agents Backend Environment Variables
+
+- **Single source of truth:** `service/system_info.go` — read env vars in `Init()` and expose via `SystemInfoService` getters.
+- **No YAML config** — do not add viper/config files; all runtime settings are environment variables.
+- **PostgreSQL:** use `AGENTS_BACKEND_POSTGRESQL_*` prefix (`HOST`, `PORT`, `DB_NAME`, `USERNAME`, `PASSWORD`).
+- **Defaults:** define defaults in `system_info.go` setters (e.g. `localhost`, `5432`, `apihub_agents_backend`) — do not duplicate as scattered literals in services.
+- **New env var:** add constant, setter, getter in `system_info.go`; wire usage in services; update Helm values in `qubership-apihub` when deploy-visible.

--- a/.github/instructions/agents-backend-migrations.instructions.md
+++ b/.github/instructions/agents-backend-migrations.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Agents-backend SQL migration path conventions
+applyTo: "**/resources/migrations/**"
+---
+
+# Agents Backend Database Migrations
+
+- Migrations live in `qubership-apihub-agents-backend/resources/migrations/`.
+- Use the next unused numeric prefix (current highest is visible in that directory).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- Migrations run at startup via `DBMigrationService` while the init HTTP server is listening; failure stops the process.

--- a/.github/instructions/agents-backend-openapi.instructions.md
+++ b/.github/instructions/agents-backend-openapi.instructions.md
@@ -1,0 +1,14 @@
+---
+description: Agents-backend OpenAPI file list and sync requirements
+applyTo: docs/api/**,qubership-apihub-agents-backend/controller/**
+---
+
+# Agents Backend OpenAPI Files
+
+Any REST endpoint or contract change **must** update the relevant OpenAPI files under `docs/api/`:
+
+- Public API: `docs/api/Agents-Backend-API.yaml`
+- Admin API: `docs/api/Admin-API.yaml`
+- Internal API: `docs/api/Agents-Backend-API_internal.yaml` (when internal endpoints change)
+
+Do not introduce breaking public API changes without versioning and deprecation.

--- a/.github/instructions/api-first-openapi.instructions.md
+++ b/.github/instructions/api-first-openapi.instructions.md
@@ -1,0 +1,10 @@
+---
+description: API-first OpenAPI sync principle for REST changes
+applyTo: "docs/api/**,**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.github/instructions/apihub-agents-backend-developer.instructions.md
+++ b/.github/instructions/apihub-agents-backend-developer.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Agents-backend development workflow for qubership-apihub-agents-backend.
+applyTo: "qubership-apihub-agents-backend/**/*.go"
+---
+
+When implementing or modifying the APIHUB Agents Backend Go service (controllers, services,
+repositories, migrations, service.go wiring, exception errors, or OpenAPI specs) in
+`qubership-apihub-agents-backend`, apply the `apihub-agents-backend-developer` skill.

--- a/.github/instructions/apihub-go-developer.instructions.md
+++ b/.github/instructions/apihub-go-developer.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Go backend development workflow for APIHub services.
+applyTo: "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.github/instructions/apihub-go-self-review.instructions.md
+++ b/.github/instructions/apihub-go-self-review.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Self-review Go backend changes against APIHub project standards.
+applyTo: "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.github/instructions/ci-super-linter.instructions.md
+++ b/.github/instructions/ci-super-linter.instructions.md
@@ -1,6 +1,6 @@
 ---
-paths:
-  - "**"
+description: CI super-linter and MD link checker rules for changed files in APIHub repositories
+applyTo: "**"
 ---
 
 # CI linters (super-linter / link checker)

--- a/.github/instructions/clarify-before-coding.instructions.md
+++ b/.github/instructions/clarify-before-coding.instructions.md
@@ -1,0 +1,10 @@
+---
+description: Ask clarifying questions before generating code when requirements are unclear
+applyTo: "**"
+---
+
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.github/instructions/english-developer-style.instructions.md
+++ b/.github/instructions/english-developer-style.instructions.md
@@ -1,0 +1,52 @@
+---
+description: British-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
+applyTo: "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.github/instructions/github-ticket-implementation-planner.instructions.md
+++ b/.github/instructions/github-ticket-implementation-planner.instructions.md
@@ -1,0 +1,7 @@
+---
+description: Plan implementation from a GitHub issue with clarifying questions and approved plan posting.
+applyTo: "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.github/instructions/go-comments.instructions.md
+++ b/.github/instructions/go-comments.instructions.md
@@ -1,0 +1,21 @@
+---
+description: Go comment policy and entity-to-view converter naming
+applyTo: "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.github/instructions/go-constants-and-http.instructions.md
+++ b/.github/instructions/go-constants-and-http.instructions.md
@@ -1,0 +1,18 @@
+---
+description: Go constants, literals, and HTTP status code conventions
+applyTo: "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.github/instructions/go-error-handling.instructions.md
+++ b/.github/instructions/go-error-handling.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Go error handling — fail fast and fix root cause
+applyTo: "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.github/instructions/go-migrations.instructions.md
+++ b/.github/instructions/go-migrations.instructions.md
@@ -1,0 +1,11 @@
+---
+description: SQL migration numbering and file conventions
+applyTo: "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.github/instructions/sql-performance.instructions.md
+++ b/.github/instructions/sql-performance.instructions.md
@@ -1,0 +1,14 @@
+---
+description: SQL performance review for repository changes
+applyTo: "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -26,7 +26,9 @@ VALIDATE_GO=false
 VALIDATE_GO_MODULES=false
 
 # Exclude specific CMD files from EditorConfig checks due to line ending conflicts
-FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)
+FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)|(/|^)\.(cursor|claude|agents)(/|$)
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
 
 # Another tool used in APIHUB for typescript linting
 VALIDATE_CSS_PRETTIER=false

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -25,10 +25,10 @@ VALIDATE_PYTHON_PYLINT=false
 VALIDATE_GO=false
 VALIDATE_GO_MODULES=false
 
-# Exclude specific CMD files from EditorConfig checks due to line ending conflicts
-FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)|(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
-MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
-NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+# APM agent content (deployed harness + local package sources + compiled agent docs)
+FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)|(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
 
 # Another tool used in APIHUB for typescript linting
 VALIDATE_CSS_PRETTIER=false

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -26,9 +26,9 @@ VALIDATE_GO=false
 VALIDATE_GO_MODULES=false
 
 # Exclude specific CMD files from EditorConfig checks due to line ending conflicts
-FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)|(/|^)\.(cursor|claude|agents)(/|$)
-MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
-NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+FILTER_REGEX_EXCLUDE=(build_docker_image\.cmd|build_golang_binary\.cmd)|(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
 
 # Another tool used in APIHUB for typescript linting
 VALIDATE_CSS_PRETTIER=false

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -19,6 +19,16 @@ jobs:
         with:
           args: >-
             './**/*.md'
+            --exclude-path '.cursor/**'
+            --exclude-path '.claude/**'
+            --exclude-path '.agents/**'
+            --exclude-path '.github/instructions/**'
+            --exclude-path '.github/skills/**'
+            --exclude-path '.github/prompts/**'
+            --exclude-path 'agent-packages/**'
+            --exclude-path 'AGENTS.md'
+            --exclude-path 'GEMINI.md'
+            --exclude-path 'CLAUDE.md'
             --verbose
             --no-progress
             --user-agent 'Mozilla/5.0 (X11; Linux x86_64) Chrome/134.0.0.0'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 go.sum
 qubership-apihub-agents-backend/qubership-apihub-agents-backend
 qubership-apihub-agents-backend/qubership-apihub-agents-backend.exe
+
+# APM cache (installed package sources)
+apm_modules/
+
+# apm pack output
+agent-packages/**/build/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,7 @@
 ^.*example.com
 ^.*xmlsoap.org
+
+# APM-deployed agent harness (upstream package markdown)
+^\.cursor/
+^\.claude/
+^\.agents/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,6 @@
 ^\.cursor/
 ^\.claude/
 ^\.agents/
+^\.github/instructions/
+^\.github/skills/
+^\.github/prompts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,188 @@
+# APIHUB Agents Backend — Agent Instructions
+
+Instructions for AI assistants working on **qubership-apihub-agents-backend** (Cursor, Claude Code, and compatible tools).
+
+This microservice manages and orchestrates [APIHUB agent](https://github.com/Netcracker/qubership-apihub-agent) instances: agent registration, discovery orchestration, snapshot management, namespace security checks, and proxying requests to agents. It stores agent state in PostgreSQL and integrates with the main APIHUB backend for permissions, publishing, and authentication.
+
+## Clarification before coding
+
+- Do **not** generate or modify code until the task requirements are clear.
+- Ask targeted questions when scope, behavior, acceptance criteria, or API contract is ambiguous.
+- For GitHub ticket work, use the project skill `github-ticket-implementation-planner` before implementation.
+- If you must assume something, state assumptions explicitly and keep changes minimal until confirmed.
+
+## Error handling: fail fast, fix root cause (not symptoms)
+
+Applies to **bug fixes and new features**.
+
+### Bug fixes
+
+- **Find and fix the root cause** — trace the failure (logs, stack, agent/APIHUB client response, DB state). Do not mask symptoms.
+- **Forbidden as a “fix”** unless the user explicitly requests a temporary workaround and documents it:
+  - Swallowing errors (`_ = err`, ignored `err`, empty result after failed DB/API/agent calls).
+  - Silent fallbacks when discovery, snapshot, or security-check operations failed.
+  - Broad `recover()` or generic handlers that hide the real failure.
+
+### New code and refactors
+
+- **Propagate errors** from repositories and services; map to HTTP at the controller boundary.
+- Use **`exception.CustomError`** for client-facing API errors (see **API errors** below).
+- **Fail fast** on fatal startup wiring (`log.Fatalf` / `panic` patterns in `service.go` for migration failure, auth setup, API spec discovery, etc.).
+- **Log errors** at ERROR for unrecoverable failures; DEBUG for expected client errors passed through `RespondWithCustomError`.
+- Background jobs (`CleanupService` cron) must log failures — do not leave scheduled work failing silently.
+
+### Before submitting a bug-fix diff
+
+Briefly state: **root cause**, **why the change fixes it**, and confirm you did **not** add swallow-and-continue logic.
+
+## Libraries and dependencies
+
+- Do **not** reimplement functionality available in established libraries already used here (gorilla/mux, go-pg, logrus, resty, go-guardian, cron, excelize).
+- Prefer existing clients (`client/agent.go`, `client/apihub.go`) and repository patterns over ad-hoc DB or HTTP code.
+- Justify any **new** Go module dependency briefly.
+
+## GitHub CLI
+
+- Use **`gh`** for issues, pull requests, checks, and releases.
+- If `gh` is missing or not authenticated, tell the user — do not scrape GitHub HTML.
+
+## Cross-platform development (Windows + Linux)
+
+- Team uses **Linux** and **Windows (often with WSL)**.
+- Go module and runnable binary live under `qubership-apihub-agents-backend/`; run `go test` / `go build` from that directory unless the task says otherwise.
+- Prefer repo-relative paths like `qubership-apihub-agents-backend/controller/...`.
+
+## Related repositories
+
+| Repo | Relationship |
+|------|----------------|
+| **qubership-apihub-backend** | Runtime dependency — permissions, package/version publishing, auth validation via `client/apihub.go` (`APIHUB_URL`, `APIHUB_ACCESS_TOKEN`). REST contract changes there may require agents-backend client or behaviour updates. |
+| **qubership-apihub-agent** | Downstream agent instances — discovery, snapshot collection, proxy targets. Agent API changes may require updates to `client/agent.go` and controllers. |
+| **qubership-apihub-ui** | Consumes agents-backend REST endpoints for the Agents tab in the portal. |
+| **qubership-apihub** | Helm charts — env vars for PostgreSQL, APIHUB URL, probes (`values.yaml` → `qubershipApihubAgentsBackend`). |
+| **qubership-apihub-ci** | Shared super-linter workflows and generic agent packages (`agent-packages/`). |
+
+When a change affects REST contracts, env vars, or integration behaviour, **remind** the developer if follow-up is needed in backend, agent, UI, or Helm — this workspace may not contain those repos.
+
+## Repository layout
+
+| Area | Location |
+|------|----------|
+| Entry point / route registration | `qubership-apihub-agents-backend/service.go` |
+| HTTP controllers | `qubership-apihub-agents-backend/controller/` |
+| Business logic | `qubership-apihub-agents-backend/service/` |
+| Data access | `qubership-apihub-agents-backend/repository/` |
+| DB entities | `qubership-apihub-agents-backend/entity/` |
+| API DTOs | `qubership-apihub-agents-backend/view/` |
+| API error codes | `qubership-apihub-agents-backend/exception/errors.go` |
+| Agent / APIHUB HTTP clients | `qubership-apihub-agents-backend/client/` |
+| Auth middleware | `qubership-apihub-agents-backend/security/` |
+| SQL migrations | `qubership-apihub-agents-backend/resources/migrations/` |
+| OpenAPI specs (this service) | `docs/api/Agents-Backend-API.yaml`, `docs/api/Admin-API.yaml`, `docs/api/Agents-Backend-API_internal.yaml` |
+| Architecture diagram | `docs/recources/arch_diagram.png` |
+
+## Domain model (read before changing agent flow)
+
+### Agent lifecycle
+
+1. **Registration** — agents POST heartbeat to `/api/v2/agents`; `AgentService` upserts agent records in PostgreSQL.
+2. **Inactive detection** — agents without recent heartbeats are marked inactive.
+3. **Namespaces** — list namespaces and service names via agent client calls.
+
+### Discovery orchestration
+
+1. **Trigger** — POST discover endpoint; `DiscoveryService` calls the agent discovery API after permission checks.
+2. **Results** — list discovered services via v3 endpoint (v2 deprecated).
+
+### Snapshots
+
+1. **Create** — collect specs from agent, package as ZIP, publish to APIHUB as package version.
+2. **Cleanup** — cron job removes old snapshots based on `SNAPSHOTS_TTL_DAYS`.
+
+### Proxy
+
+- Routes under `/api/v2/agents/{agentId}/namespaces/{namespace}/services/{serviceId}/proxy/` forward to agent instances.
+- Deprecated path `/agents/{agentId}/.../proxy/` controlled by `INSECURE_PROXY`.
+
+## Startup and migration pattern
+
+`service.go` uses a two-phase startup:
+
+1. **Init server** — temporary HTTP server starts immediately (health endpoints available).
+2. **Migration goroutine** — `DBMigrationService.Migrate()` runs against PostgreSQL; on success, init server shuts down.
+3. **Full wiring** — repositories, services, controllers, routes, and api-spec-exposer registration.
+
+Do not reorder this sequence without understanding `/live` and `/ready` behaviour and migration failure handling (failed migration stops the process after a delay).
+
+## Configuration (env-only)
+
+All settings via environment variables in `service/system_info.go` — no YAML config files.
+
+| Variable group | Key env vars |
+|----------------|--------------|
+| PostgreSQL | `AGENTS_BACKEND_POSTGRESQL_HOST`, `AGENTS_BACKEND_POSTGRESQL_PORT`, `AGENTS_BACKEND_POSTGRESQL_DB_NAME`, `AGENTS_BACKEND_POSTGRESQL_USERNAME`, `AGENTS_BACKEND_POSTGRESQL_PASSWORD` |
+| APIHUB | `APIHUB_URL`, `APIHUB_ACCESS_TOKEN` |
+| Paths / server | `BASE_PATH`, `API_SPEC_DIR`, `LISTEN_ADDRESS`, `ORIGIN_ALLOWED`, `LOG_LEVEL` |
+| Snapshots | `SNAPSHOTS_CLEANUP_SCHEDULE`, `SNAPSHOTS_TTL_DAYS` |
+
+## Go coding conventions (summary)
+
+Detailed rules apply via deployed `.cursor/rules/` and `.claude/rules/` (from APM). Key points for **this** repo:
+
+- **No magic numbers** — named constants; brief comment if a literal is unavoidable.
+- **HTTP status codes** — use `net/http` constants, not raw integers.
+- **Repeated strings** — extract to constants (especially error codes/messages).
+- **Comments** — only for non-obvious logic; do not map types to HTTP routes in comments.
+- **Entity → view converters** without dependencies: `Make{Name}View` in `entity/` next to the struct.
+- **Wiring in `service.go`** — follow existing order: migration → clients → repositories → services → controllers → routes → api-spec-exposer. Use `log.Fatalf` / `panic` for fatal init errors consistent with surrounding code.
+- **API errors** — client-facing codes and messages as constants in `exception/errors.go`, returned via `exception.CustomError` with `Status`, `Code`, `Message`, optional `Params` (placeholders like `$agentId`, `$param`), and `Debug` for internal detail.
+
+## REST API and OpenAPI
+
+- Follow **API-first**: update `docs/api/Agents-Backend-API.yaml` (and admin/internal specs when applicable) when REST contract changes.
+- Service exposes its own specs via api-spec-exposer from `API_SPEC_DIR` (see `service.go` discovery block).
+- Avoid breaking public API changes without explicit product approval.
+
+## Database migrations
+
+- Files: `qubership-apihub-agents-backend/resources/migrations/`.
+- Use the next unused numeric prefix; **no duplicate numbers**.
+- Provide paired `.up.sql` and `.down.sql` when rollback is required.
+- Migrations run at startup via `DBMigrationService` before the main server accepts traffic.
+
+## CI linters (super-linter / link checker)
+
+PRs run **super-linter** (see `.github/workflows/super-linter.yaml`) and **lychee** on Markdown. While writing:
+
+- **Go:** tabs in `*.go`; tabs inside raw string literals for nested indentation.
+- **Markdown:** prose lines ≤ **400** characters; one H1 per file.
+- **OpenAPI YAML:** no trailing whitespace on changed lines; match existing indentation.
+- **Links:** repo-relative paths must resolve from the editing file.
+
+Full checklist: `.cursor/rules/ci-super-linter.mdc` after `apm install`.
+
+## SQL performance
+
+- For non-trivial repository SQL: consider indexes, join cardinality, N+1 patterns, and unbounded result sets.
+
+## Testing and verification
+
+- Run targeted tests: `go test ./...` from `qubership-apihub-agents-backend/`.
+- After REST changes, sanity-check OpenAPI parity with registered routes in `service.go`.
+
+## Completion
+
+- After substantive changes, propose **one** concise conventional-commit message.
+- For an independent review, invoke `apihub-go-self-review` in a **new chat** or with a **different model**.
+
+## Project skills (Cursor / Claude)
+
+Generic skills and rules are provisioned by APM from the
+[CI store](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-packages).
+Repo-specific packages live in [`agent-packages/`](agent-packages/).
+
+```bash
+apm install --target cursor,claude --legacy-skill-paths
+```
+
+Skills auto-discover from `.cursor/skills/` and `.claude/skills/` (`apihub-go-developer`, `apihub-go-self-review`, `github-ticket-implementation-planner`, `apihub-agents-backend-developer`). See [README — AI agent configuration (APM)](README.md#ai-agent-configuration-apm).

--- a/README.md
+++ b/README.md
@@ -27,3 +27,30 @@ Presence of this plug-in in Qubership-APIHUB deployments enables `Agents` tab in
 Just run `build_golang_binary.cmd` file.
 
 For Docker builds, use `build_docker_image.cmd`.
+
+## AI agent configuration (APM)
+
+Agent context is split between a **central store** and **this repository**:
+
+| Scope | Location |
+|-------|----------|
+| Generic skills/rules (Go conventions, planner, …) | [`qubership-apihub-ci/agent-packages`](https://github.com/Netcracker/qubership-apihub-ci/tree/apm_migration/agent-packages) |
+| Agents-backend-specific packages | [`agent-packages/`](agent-packages/) in this repo |
+| Deployed harness output | `.cursor/` and `.claude/` (committed; refresh with APM) |
+
+After changing package sources or `apm.yml`, refresh deployed harness files:
+
+```bash
+# one-time: install APM (see https://microsoft.github.io/apm/)
+brew install microsoft/apm/apm   # or: pip install apm-cli
+
+# from the repository root:
+apm install --target cursor,claude --legacy-skill-paths
+```
+
+This reads root `apm.yml` (CI dependencies + local `agent-packages/`), updates
+`apm.lock.yaml`, and deploys into `.cursor/` and `.claude/`. Commit the refreshed harness
+trees together with package or manifest changes.
+
+During migration, CI dependencies may use `#apm_migration`; drop the suffix after the store PR
+merges.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Agent context is split between a **central store** and **this repository**:
 | Scope | Location |
 |-------|----------|
 | Generic skills/rules (Go conventions, planner, …) | [`qubership-apihub-ci/agent-packages`](https://github.com/Netcracker/qubership-apihub-ci/tree/apm_migration/agent-packages) |
-| Agents-backend-specific packages | [`agent-packages/`](agent-packages/) in this repo |
+| Agents-backend-specific packages | [`agent-packages/`](agent-packages/) in this repository |
 | Deployed harness output | `.cursor/` and `.claude/` (committed; refresh with APM) |
 
 After changing package sources or `apm.yml`, refresh deployed harness files:

--- a/agent-packages/README.md
+++ b/agent-packages/README.md
@@ -1,0 +1,25 @@
+# Agents-backend local agent packages
+
+Repository-specific APM packages for `qubership-apihub-agents-backend`. Generic packages come from
+[`qubership-apihub-ci/agent-packages`](https://github.com/Netcracker/qubership-apihub-ci/tree/apm_migration/agent-packages);
+this folder holds content that applies **only** to this service.
+
+Packages follow the [apm-authoring](https://github.com/Netcracker/qubership-ai-packages/tree/main/agent-packages/apm-authoring)
+layout (`agent-packages/<name>/.apm/...`).
+
+## Packages
+
+| Package | Path | Depends on (CI store) |
+|---------|------|------------------------|
+| `apihub-agents-backend-developer` | `apihub-agents-backend-developer/` | `apihub-go-developer` |
+| `agents-backend-conventions` | `agents-backend-conventions/` | — |
+
+Root `apm.yml` lists both CI store dependencies and these local paths. After edits, run from
+repository root:
+
+```bash
+apm install --target cursor,claude --legacy-skill-paths
+```
+
+Sources in `agent-packages/` and deployed `.cursor/` / `.claude/` harness trees are **committed**.
+Only `apm_modules/` is gitignored.

--- a/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-api-spec-exposer.instructions.md
+++ b/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-api-spec-exposer.instructions.md
@@ -1,0 +1,11 @@
+---
+description: Agents-backend API spec discovery via commons-go api-spec-exposer
+applyTo: qubership-apihub-agents-backend/service.go,docs/api/**
+---
+
+# Agents Backend API Spec Exposer
+
+- OpenAPI specs under `docs/api/` are exposed at runtime via `github.com/Netcracker/qubership-apihub-commons-go/api-spec-exposer`.
+- **Scan directory:** `API_SPEC_DIR` env var (default: `{BASE_PATH}/api`); place or symlink specs so discovery finds them.
+- **Registration:** in `service.go`, `exposer.New(discoveryConfig).Discover()` registers GET handlers for each discovered spec; discovery errors are fatal (`panic`).
+- When adding or renaming spec files, ensure they are discoverable under `API_SPEC_DIR` and update the source YAML in `docs/api/`.

--- a/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-env-vars.instructions.md
+++ b/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-env-vars.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Agents-backend environment variable conventions
+applyTo: qubership-apihub-agents-backend/service/system_info.go,qubership-apihub-agents-backend/**/*.go
+---
+
+# Agents Backend Environment Variables
+
+- **Single source of truth:** `service/system_info.go` — read env vars in `Init()` and expose via `SystemInfoService` getters.
+- **No YAML config** — do not add viper/config files; all runtime settings are environment variables.
+- **PostgreSQL:** use `AGENTS_BACKEND_POSTGRESQL_*` prefix (`HOST`, `PORT`, `DB_NAME`, `USERNAME`, `PASSWORD`).
+- **Defaults:** define defaults in `system_info.go` setters (e.g. `localhost`, `5432`, `apihub_agents_backend`) — do not duplicate as scattered literals in services.
+- **New env var:** add constant, setter, getter in `system_info.go`; wire usage in services; update Helm values in `qubership-apihub` when deploy-visible.

--- a/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-migrations.instructions.md
+++ b/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-migrations.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Agents-backend SQL migration path conventions
+applyTo: "**/resources/migrations/**"
+---
+
+# Agents Backend Database Migrations
+
+- Migrations live in `qubership-apihub-agents-backend/resources/migrations/`.
+- Use the next unused numeric prefix (current highest is visible in that directory).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- Migrations run at startup via `DBMigrationService` while the init HTTP server is listening; failure stops the process.

--- a/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-openapi.instructions.md
+++ b/agent-packages/agents-backend-conventions/.apm/instructions/agents-backend-openapi.instructions.md
@@ -1,0 +1,14 @@
+---
+description: Agents-backend OpenAPI file list and sync requirements
+applyTo: docs/api/**,qubership-apihub-agents-backend/controller/**
+---
+
+# Agents Backend OpenAPI Files
+
+Any REST endpoint or contract change **must** update the relevant OpenAPI files under `docs/api/`:
+
+- Public API: `docs/api/Agents-Backend-API.yaml`
+- Admin API: `docs/api/Admin-API.yaml`
+- Internal API: `docs/api/Agents-Backend-API_internal.yaml` (when internal endpoints change)
+
+Do not introduce breaking public API changes without versioning and deprecation.

--- a/agent-packages/agents-backend-conventions/apm.yml
+++ b/agent-packages/agents-backend-conventions/apm.yml
@@ -1,0 +1,6 @@
+name: agents-backend-conventions
+version: 0.1.0
+description: Agents-backend-specific always-on rules for qubership-apihub-agents-backend
+author: Qubership
+dependencies:
+  apm: []

--- a/agent-packages/apihub-agents-backend-developer/.apm/instructions/apihub-agents-backend-developer.instructions.md
+++ b/agent-packages/apihub-agents-backend-developer/.apm/instructions/apihub-agents-backend-developer.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Agents-backend development workflow for qubership-apihub-agents-backend.
+applyTo: "qubership-apihub-agents-backend/**/*.go"
+---
+
+When implementing or modifying the APIHUB Agents Backend Go service (controllers, services,
+repositories, migrations, service.go wiring, exception errors, or OpenAPI specs) in
+`qubership-apihub-agents-backend`, apply the `apihub-agents-backend-developer` skill.

--- a/agent-packages/apihub-agents-backend-developer/.apm/skills/apihub-agents-backend-developer/SKILL.md
+++ b/agent-packages/apihub-agents-backend-developer/.apm/skills/apihub-agents-backend-developer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: apihub-agents-backend-developer
+description: "Implements and modifies the APIHUB Agents Backend Go service (qubership-apihub-agents-backend): agent CRUD, discovery orchestration, snapshots, proxy, namespace security, env-only config, and OpenAPI specs. Use when adding or changing agents-backend features, REST endpoints, SQL migrations, repository queries, or Go code in qubership-apihub-agents-backend."
+---
+
+# APIHUB Agents Backend Developer
+
+**Follow `apihub-go-developer` first** — this skill adds agents-backend-specific rules for `qubership-apihub-agents-backend` only.
+
+Follow `AGENTS.md` and project rules. For examples and doc routing, see [reference.md](reference.md).
+
+## Agents-backend-specific workflow
+
+1. **Errors** — new API error codes/messages as constants in `exception/errors.go`.
+2. **Wiring** — new repos/services/controllers at the **end** of their section in `service.go`; `log.Fatalf` / `panic` for fatal startup wiring errors (match existing patterns).
+3. **Config** — all runtime settings via environment variables read in `service/system_info.go`; do not introduce YAML config files.
+4. **Migrations** — files in `qubership-apihub-agents-backend/resources/migrations/`; use next unused numeric prefix.
+5. **OpenAPI** — update `docs/api/*.yaml` when REST contract changes (see deployed `agents-backend-conventions` rules).
+6. **Related repos** — if the change touches deploy config, env vars, or REST contracts, remind the developer about Helm charts and/or the agent repo per `AGENTS.md`.
+
+## Domain areas (read before changing behaviour)
+
+| Area | Key files |
+|------|-----------|
+| Agent CRUD / heartbeats | `service/agent.go`, `controller/agent.go`, `repository/agent.go` |
+| Discovery orchestration | `service/discovery.go`, `controller/discovery.go`, `client/agent.go` |
+| Snapshots | `service/snapshot.go`, `controller/snapshot.go`, `service/cleanup.go` |
+| Agent proxy | `controller/proxy.go`, routes in `service.go` |
+| Namespace security | `service/namespace_security.go`, `controller/namespace_security.go` |
+| APIHUB integration | `client/apihub.go`, `service/permission.go` |
+
+## Startup and migration pattern
+
+`service.go` starts a temporary init HTTP server, runs DB migrations in a goroutine, shuts down the init server, then continues full wiring. Do not reorder this sequence without understanding health/readiness (`/live`, `/ready`) and migration failure handling.
+
+## Completion checklist (agents-backend additions)
+
+In addition to the `apihub-go-developer` checklist:
+
+- [ ] Go conventions and `service.go` / `exception/errors.go` rules followed.
+- [ ] REST changes reflected in `docs/api/*.yaml`.
+- [ ] New env vars documented in `service/system_info.go` and `agents-backend-conventions` rules.
+- [ ] Migrations use unique numeric prefix.
+- [ ] **Related repositories** — if applicable, reminded developer about Helm and/or agent repo updates (see `AGENTS.md`).
+
+### Related repositories (reminder block)
+
+When the feature matches criteria in `AGENTS.md`, end your message with:
+
+```markdown
+### Related repositories (follow-up outside this repo)
+- **Helm**: <what to check + repo URL from AGENTS.md>
+- **Agent**: <what to add/update + repo URL>
+```
+
+Omit sections that do not apply.
+
+Suggest invoking `apihub-go-self-review` in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/agent-packages/apihub-agents-backend-developer/.apm/skills/apihub-agents-backend-developer/reference.md
+++ b/agent-packages/apihub-agents-backend-developer/.apm/skills/apihub-agents-backend-developer/reference.md
@@ -1,0 +1,61 @@
+# APIHUB Agents Backend Developer — Reference
+
+Read this file when you need agents-backend-specific examples or doc-routing detail. Keep `SKILL.md` as the workflow checklist. Generic patterns are in `apihub-go-developer/reference.md`.
+
+## Doc routing (where to update documentation)
+
+| Change type | Update |
+|-------------|--------|
+| New or changed REST contract | `docs/api/Agents-Backend-API.yaml` (+ `Admin-API.yaml`, `Agents-Backend-API_internal.yaml` if applicable) |
+| Operational / architecture notes | `docs/recources/` (existing diagrams) |
+| AI assistant behaviour | `AGENTS.md`, `agent-packages/` |
+
+## Environment variables
+
+All configuration is env-only via `service/system_info.go`. Key groups:
+
+| Group | Variables |
+|-------|-----------|
+| PostgreSQL | `AGENTS_BACKEND_POSTGRESQL_HOST`, `AGENTS_BACKEND_POSTGRESQL_PORT`, `AGENTS_BACKEND_POSTGRESQL_DB_NAME`, `AGENTS_BACKEND_POSTGRESQL_USERNAME`, `AGENTS_BACKEND_POSTGRESQL_PASSWORD` |
+| APIHUB | `APIHUB_URL`, `APIHUB_ACCESS_TOKEN` |
+| Paths | `BASE_PATH`, `API_SPEC_DIR` |
+| Server | `LISTEN_ADDRESS`, `ORIGIN_ALLOWED`, `LOG_LEVEL` |
+| Snapshots cleanup | `SNAPSHOTS_CLEANUP_SCHEDULE`, `SNAPSHOTS_TTL_DAYS` |
+| Proxy (deprecated path) | `INSECURE_PROXY` |
+
+## Error codes (`exception/errors.go`)
+
+**Good:**
+
+```go
+const AgentNotFound = "4"
+const AgentNotFoundMsg = "Agent '$agentId' not found"
+```
+
+Use existing patterns for parameter placeholders (`$agentId`, `$param`, etc.). Do not inline error code strings in controllers or services.
+
+## service.go wiring
+
+- Add `repository.New...` with other repository constructors (end of repository block).
+- Add `service.New...` with other services (end of service block).
+- Add `controller.New...` with other controllers (end of controller block).
+- Use `log.Fatalf` or `panic` when service construction failure must stop startup (see existing patterns).
+
+## Migration files
+
+Naming: `{N}_{description}.up.sql` and `{N}_{description}.down.sql` where `N` is the next free integer.
+
+Directory: `qubership-apihub-agents-backend/resources/migrations/`
+
+## OpenAPI files
+
+| File | Purpose |
+|------|---------|
+| `docs/api/Agents-Backend-API.yaml` | Public REST API |
+| `docs/api/Admin-API.yaml` | Admin/debug endpoints |
+| `docs/api/Agents-Backend-API_internal.yaml` | Internal endpoints |
+
+## Further reading
+
+- `AGENTS.md` — agent contract (loaded every session)
+- `LLM/qubership-apihub-agents-backend.md` — architecture overview (when available in workspace)

--- a/agent-packages/apihub-agents-backend-developer/apm.yml
+++ b/agent-packages/apihub-agents-backend-developer/apm.yml
@@ -1,0 +1,7 @@
+name: apihub-agents-backend-developer
+version: 0.1.0
+description: Agents-backend service specifics (agent CRUD, discovery, snapshots, proxy, env config, OpenAPI)
+author: Qubership
+dependencies:
+  apm:
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration

--- a/agent-packages/apihub-agents-backend-developer/apm.yml
+++ b/agent-packages/apihub-agents-backend-developer/apm.yml
@@ -4,4 +4,5 @@ description: Agents-backend service specifics (agent CRUD, discovery, snapshots,
 author: Qubership
 dependencies:
   apm:
-    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
+

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,134 @@
+lockfile_version: '1'
+generated_at: '2026-06-03T10:52:57.141409+00:00'
+apm_version: 0.16.0
+dependencies:
+- repo_url: Netcracker/qubership-ai-packages
+  host: github.com
+  resolved_commit: 3024f029cbc9042d6905037d2fa0a98e7b6e27f2
+  resolved_ref: v1.0.1
+  virtual_path: agent-packages/english-developer-style
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/english-developer-style.md
+  - .claude/skills/english-developer-style
+  - .cursor/rules/english-developer-style.mdc
+  - .cursor/skills/english-developer-style
+  deployed_file_hashes:
+    .claude/rules/english-developer-style.md: sha256:71d5921cbb7e91db77b2ad7403714cc4d8471e3af7a974b850e9831df2ca25b9
+    .cursor/rules/english-developer-style.mdc: sha256:981d72b4b97f7b5fb861ea9beb32edef5746c8ed87419abaadc999e14861a6a9
+  content_hash: sha256:107dd671a330a3afcb3bcce940afa130f5576c17840cee77d9fcefeb4550c68c
+- repo_url: _local/agents-backend-conventions
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/agents-backend-api-spec-exposer.md
+  - .claude/rules/agents-backend-env-vars.md
+  - .claude/rules/agents-backend-migrations.md
+  - .claude/rules/agents-backend-openapi.md
+  - .cursor/rules/agents-backend-api-spec-exposer.mdc
+  - .cursor/rules/agents-backend-env-vars.mdc
+  - .cursor/rules/agents-backend-migrations.mdc
+  - .cursor/rules/agents-backend-openapi.mdc
+  deployed_file_hashes:
+    .claude/rules/agents-backend-api-spec-exposer.md: sha256:e83439f0d0e3c112e2e22beefa5ebcf1e050a189e012a904061dd35baed581b1
+    .claude/rules/agents-backend-env-vars.md: sha256:1f127d2cac53633ddc30a2350e7959e2967106da8cb862ae4c40a0535d9120c6
+    .claude/rules/agents-backend-migrations.md: sha256:bb10a2b65f0c204e826578c7c475a9c8aacdd5b8d8479443116213d64eeb61dc
+    .claude/rules/agents-backend-openapi.md: sha256:d6c3b74d4b89670c3ea754f02e239eb2eb398b8d514d26c278e9c4e3bda21171
+    .cursor/rules/agents-backend-api-spec-exposer.mdc: sha256:1df8b92004766ca3071d1f73240b4fbc70bb5bc2b9dad7721420dd5ca635b6c5
+    .cursor/rules/agents-backend-env-vars.mdc: sha256:ef03d9ba26ef6ee5b9dea20c80dd6f14a0e988dd9d52308d8ed4df2177b21315
+    .cursor/rules/agents-backend-migrations.mdc: sha256:14e7d2f00c55f27f63165b654e27141e210cdbfb1b9980df5e7832e13690e2d9
+    .cursor/rules/agents-backend-openapi.mdc: sha256:0688a1fca8d6c7ecb4acfaecc1dbbeb6909657835e6db1e6c1e29a6b078099d8
+  source: local
+  local_path: ./agent-packages/agents-backend-conventions
+- repo_url: _local/apihub-agents-backend-developer
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/apihub-agents-backend-developer.md
+  - .claude/skills/apihub-agents-backend-developer
+  - .cursor/rules/apihub-agents-backend-developer.mdc
+  - .cursor/skills/apihub-agents-backend-developer
+  deployed_file_hashes:
+    .claude/rules/apihub-agents-backend-developer.md: sha256:b89245a0680def6d8add249c21f8ac0a3309d7287089b87a4fec819a20084d0b
+    .cursor/rules/apihub-agents-backend-developer.mdc: sha256:168932b68fef4d4800ec6dfae401cf41111c88976c9affdc5e4455bf36cbd5d5
+  source: local
+  local_path: ./agent-packages/apihub-agents-backend-developer
+- repo_url: _local/apihub-go-developer
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/apihub-go-developer.md
+  - .claude/skills/apihub-go-developer
+  - .cursor/rules/apihub-go-developer.mdc
+  - .cursor/skills/apihub-go-developer
+  deployed_file_hashes:
+    .claude/rules/apihub-go-developer.md: sha256:a7ab06cdc6e814ed225065319e1cd20270dee2172ea41d0b1124ff84fc6bf799
+    .cursor/rules/apihub-go-developer.mdc: sha256:bf6ce2a6cc2faea88310673288176fd37c172266b070eb761dd924e99cfa01e3
+  source: local
+  local_path: ../qubership-apihub-ci/agent-packages/apihub-go-developer
+- repo_url: _local/apihub-go-self-review
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/apihub-go-self-review.md
+  - .claude/skills/apihub-go-self-review
+  - .cursor/rules/apihub-go-self-review.mdc
+  - .cursor/skills/apihub-go-self-review
+  deployed_file_hashes:
+    .claude/rules/apihub-go-self-review.md: sha256:09190a6cb552a30eaa215473633f833eb9fe6c6852c679c552f799b910f3031b
+    .cursor/rules/apihub-go-self-review.mdc: sha256:bec195119cfd4aaff319c0f54d1b4445d8d9b082bd4a7a932420efcaa309eb27
+  source: local
+  local_path: ../qubership-apihub-ci/agent-packages/apihub-go-self-review
+- repo_url: _local/common-conventions
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/clarify-before-coding.md
+  - .cursor/rules/clarify-before-coding.mdc
+  deployed_file_hashes:
+    .claude/rules/clarify-before-coding.md: sha256:a3e34e5277a4a3fba12fd6f236e921a59c561e6ee82e240eec247861aa8a398c
+    .cursor/rules/clarify-before-coding.mdc: sha256:ceb003b39ea330002556d10d3ca52445909bbaf23705ff27f2643705db98c0f4
+  source: local
+  local_path: ../qubership-apihub-ci/agent-packages/common-conventions
+- repo_url: _local/github-ticket-implementation-planner
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/github-ticket-implementation-planner.md
+  - .claude/skills/github-ticket-implementation-planner
+  - .cursor/rules/github-ticket-implementation-planner.mdc
+  - .cursor/skills/github-ticket-implementation-planner
+  deployed_file_hashes:
+    .claude/rules/github-ticket-implementation-planner.md: sha256:4e13f07f0749bcfd778fe44899221bff81152ee83a90b74fc7dcfafff838353c
+    .cursor/rules/github-ticket-implementation-planner.mdc: sha256:67d9c2440bc50c68b21b1afd6aa25c0a8447db76bfa7c0a7898920a3cf297d20
+  source: local
+  local_path: ../qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
+- repo_url: _local/go-conventions
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/api-first-openapi.md
+  - .claude/rules/ci-super-linter.md
+  - .claude/rules/go-comments.md
+  - .claude/rules/go-constants-and-http.md
+  - .claude/rules/go-error-handling.md
+  - .claude/rules/go-migrations.md
+  - .claude/rules/sql-performance.md
+  - .cursor/rules/api-first-openapi.mdc
+  - .cursor/rules/ci-super-linter.mdc
+  - .cursor/rules/go-comments.mdc
+  - .cursor/rules/go-constants-and-http.mdc
+  - .cursor/rules/go-error-handling.mdc
+  - .cursor/rules/go-migrations.mdc
+  - .cursor/rules/sql-performance.mdc
+  deployed_file_hashes:
+    .claude/rules/api-first-openapi.md: sha256:2e28a945412a344a23f5900f4704ef6a6a7ceedb0c599056ba09e63432a7bab4
+    .claude/rules/ci-super-linter.md: sha256:61ba8e911259ed5a8f0d9a9c7d6762c694d9e231dfa4f498a7d67c276958cd36
+    .claude/rules/go-comments.md: sha256:57c3326eed8a055caaad74c140917c078778ff04f562cba845d22df63e98b582
+    .claude/rules/go-constants-and-http.md: sha256:f8d52303334e63092309d62e29085321b32a8bb8c4bce8ca38cd79af56f43a69
+    .claude/rules/go-error-handling.md: sha256:61407348b5d86d8e2cf730816c13d04e7fdea3a20be38a5b3405b01a6ce71cb2
+    .claude/rules/go-migrations.md: sha256:1d3e486379993f6fe68d2f4b53f3e2207154988a09b9c1c5ab98659a910edc88
+    .claude/rules/sql-performance.md: sha256:d826f635a958a4e5295a5e3e30f9fe61844a77e987a6d474308083985a91c1af
+    .cursor/rules/api-first-openapi.mdc: sha256:1ec7880c515db06e1d852395d7d8a5728bce08b20b9e1087115a03956d73bcb7
+    .cursor/rules/ci-super-linter.mdc: sha256:32577dcadb66177e4a61a592be195b01b4d13876d3928c69c024d7e563ab013a
+    .cursor/rules/go-comments.mdc: sha256:f8e9df333a575ef38519b7415f0301235563fdd3dc18867b49dfbc8690de3fca
+    .cursor/rules/go-constants-and-http.mdc: sha256:778efcf145d35ccc3314f68cf0d54e33c1f13ef0ba4a19e809b4b24be80fc9bb
+    .cursor/rules/go-error-handling.mdc: sha256:9c084d61f2b27040a50c277a481232b00ecfd62b7b6da8b6aa7c86aaa184ba6c
+    .cursor/rules/go-migrations.mdc: sha256:79ab6bc7ae81f74719b4ccfbc9b5ce2146ee7ef1c58f47031cf2a742a9765297
+    .cursor/rules/sql-performance.mdc: sha256:b8748ddf13e089c63529ae6423a7fb930a8cfae4160c3366e276c6bf4fac5138
+  source: local
+  local_path: ../qubership-apihub-ci/agent-packages/go-conventions

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,22 +1,23 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T10:52:57.141409+00:00'
+generated_at: '2026-06-03T14:56:58.657364+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: Netcracker/qubership-ai-packages
   host: github.com
-  resolved_commit: 3024f029cbc9042d6905037d2fa0a98e7b6e27f2
-  resolved_ref: v1.0.1
+  resolved_commit: 785ac701be71e5f09f8857970c026d5f6bbbbb1a
   virtual_path: agent-packages/english-developer-style
   is_virtual: true
   package_type: apm_package
   deployed_files:
+  - .agents/skills/english-developer-style
   - .claude/rules/english-developer-style.md
   - .claude/skills/english-developer-style
   - .cursor/rules/english-developer-style.mdc
-  - .cursor/skills/english-developer-style
+  - .github/instructions/english-developer-style.instructions.md
   deployed_file_hashes:
     .claude/rules/english-developer-style.md: sha256:71d5921cbb7e91db77b2ad7403714cc4d8471e3af7a974b850e9831df2ca25b9
     .cursor/rules/english-developer-style.mdc: sha256:981d72b4b97f7b5fb861ea9beb32edef5746c8ed87419abaadc999e14861a6a9
+    .github/instructions/english-developer-style.instructions.md: sha256:9bd3f0ea1da9c84677b4d7e91126208b437bc93b82ea6c684e1d76db9e42abde
   content_hash: sha256:107dd671a330a3afcb3bcce940afa130f5576c17840cee77d9fcefeb4550c68c
 - repo_url: _local/agents-backend-conventions
   package_type: apm_package
@@ -29,6 +30,10 @@ dependencies:
   - .cursor/rules/agents-backend-env-vars.mdc
   - .cursor/rules/agents-backend-migrations.mdc
   - .cursor/rules/agents-backend-openapi.mdc
+  - .github/instructions/agents-backend-api-spec-exposer.instructions.md
+  - .github/instructions/agents-backend-env-vars.instructions.md
+  - .github/instructions/agents-backend-migrations.instructions.md
+  - .github/instructions/agents-backend-openapi.instructions.md
   deployed_file_hashes:
     .claude/rules/agents-backend-api-spec-exposer.md: sha256:e83439f0d0e3c112e2e22beefa5ebcf1e050a189e012a904061dd35baed581b1
     .claude/rules/agents-backend-env-vars.md: sha256:1f127d2cac53633ddc30a2350e7959e2967106da8cb862ae4c40a0535d9120c6
@@ -38,97 +43,125 @@ dependencies:
     .cursor/rules/agents-backend-env-vars.mdc: sha256:ef03d9ba26ef6ee5b9dea20c80dd6f14a0e988dd9d52308d8ed4df2177b21315
     .cursor/rules/agents-backend-migrations.mdc: sha256:14e7d2f00c55f27f63165b654e27141e210cdbfb1b9980df5e7832e13690e2d9
     .cursor/rules/agents-backend-openapi.mdc: sha256:0688a1fca8d6c7ecb4acfaecc1dbbeb6909657835e6db1e6c1e29a6b078099d8
+    .github/instructions/agents-backend-api-spec-exposer.instructions.md: sha256:9237a31f6caf4a9d0dae44c44228832f5b2a1eb43a583df3bc89d500419d5ae2
+    .github/instructions/agents-backend-env-vars.instructions.md: sha256:91c3177515431124e7a2b2ee4cccf66c43c597cfebff21c53cbe19330ec2fafe
+    .github/instructions/agents-backend-migrations.instructions.md: sha256:610214b6764736a30bd4c219ee160d612975cad30b1db0e03d653a03208fc7f0
+    .github/instructions/agents-backend-openapi.instructions.md: sha256:7625a67a35879d509891fe199a7777fe2eed307b658dd83e0f8734263213edc0
   source: local
   local_path: ./agent-packages/agents-backend-conventions
 - repo_url: _local/apihub-agents-backend-developer
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apihub-agents-backend-developer
   - .claude/rules/apihub-agents-backend-developer.md
   - .claude/skills/apihub-agents-backend-developer
   - .cursor/rules/apihub-agents-backend-developer.mdc
-  - .cursor/skills/apihub-agents-backend-developer
+  - .github/instructions/apihub-agents-backend-developer.instructions.md
   deployed_file_hashes:
     .claude/rules/apihub-agents-backend-developer.md: sha256:b89245a0680def6d8add249c21f8ac0a3309d7287089b87a4fec819a20084d0b
     .cursor/rules/apihub-agents-backend-developer.mdc: sha256:168932b68fef4d4800ec6dfae401cf41111c88976c9affdc5e4455bf36cbd5d5
+    .github/instructions/apihub-agents-backend-developer.instructions.md: sha256:ba5b77c8624e1cd18e2c57de861a20bd62e8691bd11d611996f4bf5b4104bea5
   source: local
   local_path: ./agent-packages/apihub-agents-backend-developer
 - repo_url: _local/apihub-go-developer
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apihub-go-developer
   - .claude/rules/apihub-go-developer.md
   - .claude/skills/apihub-go-developer
   - .cursor/rules/apihub-go-developer.mdc
-  - .cursor/skills/apihub-go-developer
+  - .github/instructions/apihub-go-developer.instructions.md
   deployed_file_hashes:
     .claude/rules/apihub-go-developer.md: sha256:a7ab06cdc6e814ed225065319e1cd20270dee2172ea41d0b1124ff84fc6bf799
     .cursor/rules/apihub-go-developer.mdc: sha256:bf6ce2a6cc2faea88310673288176fd37c172266b070eb761dd924e99cfa01e3
+    .github/instructions/apihub-go-developer.instructions.md: sha256:ef1557c50549af71a9a6384c6a25483e4a69f5ce5429384357b21d3b3818e495
   source: local
   local_path: ../qubership-apihub-ci/agent-packages/apihub-go-developer
 - repo_url: _local/apihub-go-self-review
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apihub-go-self-review
   - .claude/rules/apihub-go-self-review.md
   - .claude/skills/apihub-go-self-review
   - .cursor/rules/apihub-go-self-review.mdc
-  - .cursor/skills/apihub-go-self-review
+  - .github/instructions/apihub-go-self-review.instructions.md
   deployed_file_hashes:
     .claude/rules/apihub-go-self-review.md: sha256:09190a6cb552a30eaa215473633f833eb9fe6c6852c679c552f799b910f3031b
     .cursor/rules/apihub-go-self-review.mdc: sha256:bec195119cfd4aaff319c0f54d1b4445d8d9b082bd4a7a932420efcaa309eb27
+    .github/instructions/apihub-go-self-review.instructions.md: sha256:ca5b2d888ed042eed2c904d5d68ae74df7435204409a3ba08dbbde3db8756951
   source: local
   local_path: ../qubership-apihub-ci/agent-packages/apihub-go-self-review
-- repo_url: _local/common-conventions
+- repo_url: _local/development-conventions
   package_type: apm_package
   deployed_files:
+  - .claude/rules/ci-super-linter.md
   - .claude/rules/clarify-before-coding.md
+  - .cursor/rules/ci-super-linter.mdc
   - .cursor/rules/clarify-before-coding.mdc
+  - .github/instructions/ci-super-linter.instructions.md
+  - .github/instructions/clarify-before-coding.instructions.md
   deployed_file_hashes:
+    .claude/rules/ci-super-linter.md: sha256:d655a548333e52a748113632665f810e3fb6084339852306aca90f02cfb4f0c7
     .claude/rules/clarify-before-coding.md: sha256:a3e34e5277a4a3fba12fd6f236e921a59c561e6ee82e240eec247861aa8a398c
+    .cursor/rules/ci-super-linter.mdc: sha256:2f264db238d0d7ffd9d8b830dd383233c57b20e057557d65084fe3f0e7512967
     .cursor/rules/clarify-before-coding.mdc: sha256:ceb003b39ea330002556d10d3ca52445909bbaf23705ff27f2643705db98c0f4
+    .github/instructions/ci-super-linter.instructions.md: sha256:7e8e2395715e9bd69ec938d4e106ec16d0e9256053c1562cf915a40bf33c7fe5
+    .github/instructions/clarify-before-coding.instructions.md: sha256:f0723cdf5b2cc34bc46992a6c550842f8eb9dcc5b39540c9916835a4ee58d60d
   source: local
-  local_path: ../qubership-apihub-ci/agent-packages/common-conventions
+  local_path: ../qubership-apihub-ci/agent-packages/development-conventions
 - repo_url: _local/github-ticket-implementation-planner
   package_type: apm_package
   deployed_files:
+  - .agents/skills/github-ticket-implementation-planner
   - .claude/rules/github-ticket-implementation-planner.md
   - .claude/skills/github-ticket-implementation-planner
   - .cursor/rules/github-ticket-implementation-planner.mdc
-  - .cursor/skills/github-ticket-implementation-planner
+  - .github/instructions/github-ticket-implementation-planner.instructions.md
   deployed_file_hashes:
     .claude/rules/github-ticket-implementation-planner.md: sha256:4e13f07f0749bcfd778fe44899221bff81152ee83a90b74fc7dcfafff838353c
     .cursor/rules/github-ticket-implementation-planner.mdc: sha256:67d9c2440bc50c68b21b1afd6aa25c0a8447db76bfa7c0a7898920a3cf297d20
+    .github/instructions/github-ticket-implementation-planner.instructions.md: sha256:e2770726d0d63444f1a2df2e848a46f29556cd638c22b5484bc21bdf5ac60264
   source: local
   local_path: ../qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
 - repo_url: _local/go-conventions
   package_type: apm_package
   deployed_files:
   - .claude/rules/api-first-openapi.md
-  - .claude/rules/ci-super-linter.md
   - .claude/rules/go-comments.md
   - .claude/rules/go-constants-and-http.md
   - .claude/rules/go-error-handling.md
   - .claude/rules/go-migrations.md
   - .claude/rules/sql-performance.md
   - .cursor/rules/api-first-openapi.mdc
-  - .cursor/rules/ci-super-linter.mdc
   - .cursor/rules/go-comments.mdc
   - .cursor/rules/go-constants-and-http.mdc
   - .cursor/rules/go-error-handling.mdc
   - .cursor/rules/go-migrations.mdc
   - .cursor/rules/sql-performance.mdc
+  - .github/instructions/api-first-openapi.instructions.md
+  - .github/instructions/go-comments.instructions.md
+  - .github/instructions/go-constants-and-http.instructions.md
+  - .github/instructions/go-error-handling.instructions.md
+  - .github/instructions/go-migrations.instructions.md
+  - .github/instructions/sql-performance.instructions.md
   deployed_file_hashes:
     .claude/rules/api-first-openapi.md: sha256:2e28a945412a344a23f5900f4704ef6a6a7ceedb0c599056ba09e63432a7bab4
-    .claude/rules/ci-super-linter.md: sha256:61ba8e911259ed5a8f0d9a9c7d6762c694d9e231dfa4f498a7d67c276958cd36
     .claude/rules/go-comments.md: sha256:57c3326eed8a055caaad74c140917c078778ff04f562cba845d22df63e98b582
     .claude/rules/go-constants-and-http.md: sha256:f8d52303334e63092309d62e29085321b32a8bb8c4bce8ca38cd79af56f43a69
     .claude/rules/go-error-handling.md: sha256:61407348b5d86d8e2cf730816c13d04e7fdea3a20be38a5b3405b01a6ce71cb2
     .claude/rules/go-migrations.md: sha256:1d3e486379993f6fe68d2f4b53f3e2207154988a09b9c1c5ab98659a910edc88
     .claude/rules/sql-performance.md: sha256:d826f635a958a4e5295a5e3e30f9fe61844a77e987a6d474308083985a91c1af
     .cursor/rules/api-first-openapi.mdc: sha256:1ec7880c515db06e1d852395d7d8a5728bce08b20b9e1087115a03956d73bcb7
-    .cursor/rules/ci-super-linter.mdc: sha256:32577dcadb66177e4a61a592be195b01b4d13876d3928c69c024d7e563ab013a
     .cursor/rules/go-comments.mdc: sha256:f8e9df333a575ef38519b7415f0301235563fdd3dc18867b49dfbc8690de3fca
     .cursor/rules/go-constants-and-http.mdc: sha256:778efcf145d35ccc3314f68cf0d54e33c1f13ef0ba4a19e809b4b24be80fc9bb
     .cursor/rules/go-error-handling.mdc: sha256:9c084d61f2b27040a50c277a481232b00ecfd62b7b6da8b6aa7c86aaa184ba6c
     .cursor/rules/go-migrations.mdc: sha256:79ab6bc7ae81f74719b4ccfbc9b5ce2146ee7ef1c58f47031cf2a742a9765297
     .cursor/rules/sql-performance.mdc: sha256:b8748ddf13e089c63529ae6423a7fb930a8cfae4160c3366e276c6bf4fac5138
+    .github/instructions/api-first-openapi.instructions.md: sha256:a0fa42fb75fa89eac5e37da4d960015ee1bbb22b3a1fc4beb94007371de10176
+    .github/instructions/go-comments.instructions.md: sha256:87f198201fb384206af8d4e2827c53c7133fa3de4d5e267834e2f5f273ccf2b9
+    .github/instructions/go-constants-and-http.instructions.md: sha256:0854f8fba840ec10b8ddf51af627208801578ea419be6d2e3ff4faa51ea68640
+    .github/instructions/go-error-handling.instructions.md: sha256:f5d8a30e9ed725693ba229392fae6d77576cdb59c4e077070902062627814251
+    .github/instructions/go-migrations.instructions.md: sha256:3a1da7a929ec634031ca03eee095b3272c0e9d5216d579a46d95cf4b6fcf68fc
+    .github/instructions/sql-performance.instructions.md: sha256:7bbfae4b968dd1f2cc024d8e28bf5df5acc188ee24d53f460ab916f19f2df069
   source: local
   local_path: ../qubership-apihub-ci/agent-packages/go-conventions

--- a/apm.yml
+++ b/apm.yml
@@ -5,7 +5,7 @@ targets:
   - claude
 dependencies:
   apm:
-    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
+    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
     - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner

--- a/apm.yml
+++ b/apm.yml
@@ -6,10 +6,11 @@ targets:
 dependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
-    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
+    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
+    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions
+    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions
     - ./agent-packages/apihub-agents-backend-developer
     - ./agent-packages/agents-backend-conventions
+

--- a/apm.yml
+++ b/apm.yml
@@ -9,7 +9,7 @@ dependencies:
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
     - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
-    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions
+    - Netcracker/qubership-apihub-ci/agent-packages/development-conventions
     - Netcracker/qubership-apihub-ci/agent-packages/go-conventions
     - ./agent-packages/apihub-agents-backend-developer
     - ./agent-packages/agents-backend-conventions

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,15 @@
+name: qubership-apihub-agents-backend
+version: 0.0.0
+targets:
+  - cursor
+  - claude
+dependencies:
+  apm:
+    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions#apm_migration
+    - ./agent-packages/apihub-agents-backend-developer
+    - ./agent-packages/agents-backend-conventions


### PR DESCRIPTION
## Summary
- Add root `apm.yml` with Cursor/Claude targets, CI generic Go packages, and local `agent-packages/` for agents-backend-specific skills and conventions.
- Add `AGENTS.md` (PostgreSQL, init-server migration pattern, related repos), local packages (`apihub-agents-backend-developer`, `agents-backend-conventions`), and deployed `.cursor/` / `.claude/` harness.
- Update `.gitignore` for `apm_modules/` and `agent-packages/**/build/`; document APM setup in README.

## Test plan
- [ ] Run `apm install --target cursor,claude --legacy-skill-paths` from repo root on Linux/macOS CI
- [ ] Verify `.cursor/skills/apihub-agents-backend-developer` and convention rules deploy correctly
- [ ] Confirm super-linter passes on new Markdown/YAML files
- [ ] Spot-check `AGENTS.md` domain sections against `service.go` routes and env vars
